### PR TITLE
fix bug showing rightmost squares in ch. 2 Ex. 8

### DIFF
--- a/Chapter02/Example08-CustomLayout/app/src/main/java/com/packt/rrafols/customview/CustomLayout.java
+++ b/Chapter02/Example08-CustomLayout/app/src/main/java/com/packt/rrafols/customview/CustomLayout.java
@@ -35,6 +35,9 @@ public class CustomLayout extends ViewGroup {
                 left = l + getPaddingLeft();
                 top += rowHeight;
                 rowHeight = 0;
+
+                child.layout(left, top, left + childWidth, top + childHeight);
+                left += childWidth;
             }
 
             // update maximum row height


### PR DESCRIPTION
CustomLayout.onLayout() was failing to lay out children who did
not fit in a row. Instead of moving them to the next row, the
children were not layed out at all.

The `MainActivity` of this example specifies that 50 child views should be added, however, even the screenshot in the book does not contain 50.

## Before Change:
![current](https://user-images.githubusercontent.com/4745799/37563976-f2e8030a-2a49-11e8-95f2-c53c3fb9f963.png)
Notice that the count of rows is 8 and the count of rectangles is 43. So for each of the first 7 rows, the final rectangle was not getting layed out.

## After Change:
![after_change](https://user-images.githubusercontent.com/4745799/37563981-15ede810-2a4a-11e8-9c6f-c080c355cf64.png)
Now the count of rectangles is 50.

