### PR TITLE
fix bug drawing texture on cube

### DIFF
--- a/Chapter05/Example25-GLDrawing/app/src/main/java/com/packt/rrafols/draw/GLDrawer.java
+++ b/Chapter05/Example25-GLDrawing/app/src/main/java/com/packt/rrafols/draw/GLDrawer.java
@@ -192,14 +192,14 @@ public class GLDrawer extends GLSurfaceView {
             GLES20.glUniform1i(texHandle, 0);
 
             GLES20.glEnable(GLES20.GL_DEPTH_TEST);
-            GLES20.glEnableVertexAttribArray(texHandle);
+            GLES20.glEnableVertexAttribArray(texCoordHandle);
             GLES20.glEnableVertexAttribArray(positionHandle);
             GLES20.glDrawElements(
                     GLES20.GL_TRIANGLES, index.length,
                     GLES20.GL_UNSIGNED_SHORT, indexBuffer);
 
             GLES20.glDisableVertexAttribArray(positionHandle);
-            GLES20.glDisableVertexAttribArray(texHandle);
+            GLES20.glDisableVertexAttribArray(texCoordHandle);
             GLES20.glDisable(GLES20.GL_DEPTH_TEST);
         }
     }


### PR DESCRIPTION
The previous version was enabling/disabling the
handle to a uniform sampler2D instead of a vertex
array attribute. This change enables/disables the
correct handle pre/post drawing elements

The screenshot in the book looks like it was taken without the issue that I see based upon the code in the repo.

## The Problem and Solution
This is the first time I've tried to use OpenGL for anything, so please correct me if my understanding is wrong, but it looks like the basic flow of using the shader program is below:

1. Tell OpenGL to use a program given the program's identifier (an int)
2. Get "handles" to attributes/uniform/varying identifiers are stored. These handles are probably locations in memory where the actual values corresponding to the identifiers are stored.
3. Perform any math you need to perform, perhaps setting the values stored in these memory locations.
4. Flag attributes as enabled
5. Draw
6. Flag attributes as disabled

It seems that `uniform`/`varying`/`attribute` declarations have special meanings (that I don't know at the moment). Instead of enabling an attribute in the call to `GLES20.glEnableVertexAttribArray`, the code is actually sending in the handle for a `uniform` identifier. So, my guess is that the enable/disable calls were failing. The solution was to pass in the correct handle.

## Before
![current_texture](https://user-images.githubusercontent.com/4745799/37872464-64da80f0-2fbd-11e8-82a6-0cb345f31ee5.png)

## After
![texture_after_changes](https://user-images.githubusercontent.com/4745799/37872466-6c631f94-2fbd-11e8-91f5-bd00c24d7dd6.png)
