### PR TITLE
fixed bug in example28, particles not animating

### DIFF
--- a/Chapter06/Example28-FixedTimestep/app/src/main/java/com/packt/rrafols/draw/FixedTimestepExample.java
+++ b/Chapter06/Example28-FixedTimestep/app/src/main/java/com/packt/rrafols/draw/FixedTimestepExample.java
@@ -24,7 +24,7 @@ public class FixedTimestepExample extends View {
     private long accTime;
     private int previousVisibility;
     private long invisibleTimeStart;
-
+    private boolean hasBeenVisible = false;
 
     public FixedTimestepExample(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
@@ -50,7 +50,7 @@ public class FixedTimestepExample extends View {
         super.onVisibilityChanged(changedView, visibility);
 
         // avoid doing this check before View is even visible
-        if (timeStart != -1) {
+        if (hasBeenVisible) {
             if ((visibility == View.INVISIBLE || visibility == View.GONE) &&
                     previousVisibility == View.VISIBLE) {
 
@@ -62,8 +62,9 @@ public class FixedTimestepExample extends View {
 
                 timeStart += SystemClock.elapsedRealtime() - invisibleTimeStart;
             }
-        } else {
+        } else if (visibility == View.VISIBLE) {
             timeStart = SystemClock.elapsedRealtime();
+            hasBeenVisible = true;
         }
 
         previousVisibility = visibility;


### PR DESCRIPTION
Particles were not animating--at least not immediately.
The reason for the bug is that timeStart was getting at least
doubled when going through onVisibilityChanged. The solution
was to add extra state to track whether the view state had
ever changed to visible.

To see the effect of this doubling, notice that you can click and drag (perform a MOVE event) and write some text on the screen in particles that should be falling (prior to making this change):
![current_fixed_timestep](https://user-images.githubusercontent.com/4745799/38121295-487123a0-3383-11e8-8a93-9d890ab917a1.png)

After the change:
![fixed_timestep_after_change](https://user-images.githubusercontent.com/4745799/38121313-58cc2f1a-3383-11e8-8a42-6c20014df145.png)
